### PR TITLE
Memory limit increased from 32 to 64

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -181,7 +181,7 @@ pm.max_requests = 500
 ;   start time           - the date and time the process has started;
 ;   start since          - the number of seconds since the process has started;
 ;   requests             - the number of requests the process has served;
-;   request duration     - the duration in µs of the requests;
+;   request duration     - the duration in Âµs of the requests;
 ;   request method       - the request method (GET, POST, ...);
 ;   request URI          - the request URI with the query string;
 ;   content length       - the content length of the request (only with POST);
@@ -389,4 +389,4 @@ catch_workers_output = yes
 ;php_flag[display_errors] = off
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
-;php_admin_value[memory_limit] = 32M
+php_admin_value[memory_limit] = 64M


### PR DESCRIPTION
Updating bootstrap_dark theme was giving error. After increasing the memory limit and restarting the php solved the problem.