### PR TITLE
Don't backup _data temporary folder (closes #17)

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -42,7 +42,7 @@ ynh_backup "$final_path"
 backup_core_only=$(ynh_app_setting_get "$app" backup_core_only)
 if [ -z $backup_core_only ]	# If backup_core_only setting set, don't backup data directory
 then
-  ynh_backup /home/yunohost.app/${app}
+  ynh_backup /home/yunohost.app/${app}/upload
 else
   echo "Data dir won't be saved, because backup_core_only is set." >&2
   # Remove the option so that next regular backup will be complete

--- a/scripts/restore
+++ b/scripts/restore
@@ -54,12 +54,14 @@ ynh_restore_file "/etc/nginx/conf.d/$domain.d/$app.conf"
 
 ynh_restore_file "$final_path"
 # Restore data directory if backed-up
-if [ -d "$YNH_BACKUP_DIR/apps/${app}/backup/home/yunohost.app/${app}" ] ; then
-  ynh_restore_file "/home/yunohost.app/${app}"
+if [ -d "$YNH_BACKUP_DIR/apps/${app}/backup/home/yunohost.app/${app}/upload" ] ; then
+  ynh_restore_file "/home/yunohost.app/${app}/upload"
 else
-  # Create app folders
-  mkdir /home/yunohost.app/${app}/_data /home/yunohost.app/${app}/upload
+  # Create app data folder
+  mkdir /home/yunohost.app/${app}/upload
 fi
+# Create temporary data folder
+mkdir -p /home/yunohost.app/${app}/_data
 # Remove the option backup_core_only if it's in the settings.yml file
 ynh_app_setting_delete $app backup_core_only
 


### PR DESCRIPTION
## Problem
`_data` folder is backed-up, whereas it's a temporary folder, duplicating the `upload` folder which contains every needed data (see #17).

## Solution
Don't backup the `_data` folder. The only drawback is that Piwigo will need to regenerate temporary data (thumbnails, different photos sizes) on the fly (as it already does when the photo is viewed/browsed for the first time).

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.  

## Validation
- [x] **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : 
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/piwigo_ynh%20enh_dont_backup__data%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/piwigo_ynh%20enh_dont_backup__data%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merge it.