### PR TITLE
Add upgrade from a previous commit

### DIFF
--- a/check_process
+++ b/check_process
@@ -13,6 +13,7 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
+		upgrade=1	from_commit=f7a6d6ca2dbbd39f20d299478c28f92e83f6f53c
 		backup_restore=1
 		multi_instance=1
 		incorrect_path=1
@@ -34,3 +35,7 @@
 ;;; Options
 Email=
 Notification=none
+;;; Upgrade options
+	; commit=f7a6d6ca2dbbd39f20d299478c28f92e83f6f53c
+		name=Take more official review comments into account
+		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr&is_public=1&


### PR DESCRIPTION
## Problem
- *Test an upgrade for each PR is boring...*

## Solution
- *Add a test "Upgrade from commit" in the check_process*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : Josué
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/piwigo_ynh%20Add-upgrade-from-a-previous-commit%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/piwigo_ynh%20Add-upgrade-from-a-previous-commit%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.