### PR TITLE
Move galleries directory to /home/yunohost.app and don't delete it during upgrade (fixes #26)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -104,14 +104,16 @@ ynh_system_user_create $app	# Create a dedicated system user
 
 # Install files and set permissions
 mkdir $final_path
-cp -a $tmpdir/!(upload|_data) $final_path
+cp -a $tmpdir/!(upload|_data|galleries) $final_path
 
 datapath=/home/yunohost.app/$app
 mkdir -p $datapath/_data
 mkdir -p $datapath/upload
+mkdir -p $datapath/galleries
 
 ln -sd $datapath/_data $final_path/_data
 ln -sd $datapath/upload $final_path/upload
+ln -sd $datapath/galleries $final_path/galleries
 
 chown -R $app: $final_path
 chown -R $app: $datapath

--- a/scripts/install
+++ b/scripts/install
@@ -115,6 +115,10 @@ ln -sd $datapath/_data $final_path/_data
 ln -sd $datapath/upload $final_path/upload
 ln -sd $datapath/galleries $final_path/galleries
 
+cp -Rp $tmpdir/_data/. $final_path/_data
+cp -Rp $tmpdir/upload/. $final_path/upload
+cp -Rp $tmpdir/galleries/. $final_path/galleries
+
 chown -R $app: $final_path
 chown -R $app: $datapath
 chmod 755 -R $final_path/_data

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -128,17 +128,8 @@ ynh_system_user_create $app # Create dedicated user if not existing
 # We store photos (potentially large data) on /home/yunohost.app
 datapath=/home/yunohost.app/$app
 
-# Backward compatibility:
-# If the galleries subdirectory was moved,
-# remove the link and overwrite it
-# (this directory always includes only a single index.php file...)
-if [ -h $final_path/galleries ] ; then
-  rm -f $final_path/galleries # only a symbolic link, ynh_secure_remove can't handle that
-  ynh_secure_remove $datapath/galleries
-fi
-
 # Install files and set permissions
-cp -a $tmpdir/!(upload|_data) $final_path
+cp -a $tmpdir/!(upload|_data|galleries) $final_path
 
 
 # Backward compatibility:
@@ -149,6 +140,13 @@ if [ ! -h $final_path/_data ] ; then
   ln -sd $datapath/_data $final_path/_data
 fi
 
+# Backward compatibility:
+# If the galleries subdirectory wasn't already moved to /home/yunohost.app/$app,
+# then move it there
+if [ ! -h $final_path/galleries ] ; then
+  mv $final_path/galleries $datapath
+  ln -sd $datapath/galleries $final_path/galleries
+fi
 
 chown -R $app: $final_path
 chown -R $app: $datapath


### PR DESCRIPTION
## Problem
- *Galleries directory is used when using the synchronization feature: it can be huge and must be kept during upgrade*

## Solution
- *Move galleries directory to /home/yunohost.app and don't delete it during upgrade*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/piwigo_ynh%20fix_galleries_directory%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/piwigo_ynh%20fix_galleries_directory%20(Official)/) 
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.